### PR TITLE
Do not save new geocodes when updated address is identical to existing

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -8,8 +8,8 @@
     <author>SYSTOPIA</author>
     <email>leichtfuss@systopia.de</email>
   </maintainer>
-  <releaseDate>2020-12-08</releaseDate>
-  <version>1.4-alpha1</version>
+  <releaseDate>2022-04-12</releaseDate>
+  <version>1.4-alpha2</version>
   <develStage>testing</develStage>
   <compatibility>
     <ver>5.0</ver>

--- a/osm.php
+++ b/osm.php
@@ -121,6 +121,9 @@ function osm_civicrm_pre($op, $objectName, $id, &$params) {
     $skip_geocode = TRUE;
     foreach ($fields_to_check as $field) {
       $skip_geocode = ($current_address[$field] == $params[$field]);
+      if (!skip_geocode) {
+        break;
+      }
     }
 
     if ($skip_geocode) {

--- a/osm.php
+++ b/osm.php
@@ -106,9 +106,6 @@ function osm_civicrm_pre($op, $objectName, $id, &$params) {
       ->execute()
       ->first();
 
-    \Civi::log()->debug('Existing addr: %s', ['%s' => json_encode($current_address)]);
-    \Civi::log()->debug('Updated addr: %s', ['%s' => json_encode($params)]);
-
     $fields_to_check = [
       'city',
       'country_id',


### PR DESCRIPTION
**Problem**
Event registrations that request only partial address information for participants (eg. postcode only) are leading to existing latitude & longitude values being set to NULL.

It seems that CiviCRM is asking the geocoder to query Nomatim/OSM for the address information supplied in the event registration, rather than the contact's address after its reconciliation with the information supplied in the registration.

For example, a geocoded address of "123 Alphabet St, Suburb, 2000 NSW Australia" will lose its lat/long values when a submission of "2000" is made through event registration.

**Solution**
This PR uses the hook_civicrm_pre hook function to ensure NULL lat/long values are removed from the data to be saved in the database when the submitted address information is identical to its matching fields in the already-stored address. Specifically, it removes the NULL geo_code_1 and geo_code_2 values from the payload to be written to the database.

**Testing**
I have tested this by registering myself (via an Incognito browser window) for an event that asks only for a postcode. First I make sure my existing address is complete and has latitude & longitude values.

Pre-patch, registering for the event, then editing my address in the Civi admin UI shows the latitude & longitude fields blank.

After applying this patch, repeating the same process shows I still have numeric values in the two fields.