### PR TITLE
Improve NULL geocode handling

### DIFF
--- a/osm.php
+++ b/osm.php
@@ -103,13 +103,10 @@ function osm_civicrm_managed(&$entities) {
 function osm_civicrm_pre($op, $objectName, $id, &$params) {
   if ($objectName === 'Address' && $op === 'edit' && !is_null($id)) {
 
-    Civi::log()->debug(json_encode($params));
-    $current_address = \Civi\Api4\Address::get(FALSE)
+    $curr_addr = \Civi\Api4\Address::get(FALSE)
       ->addWhere('id', '=', $id)
       ->execute()
       ->first();
-
-    Civi::log()->debug(json_encode($current_address));
 
     $fields_to_check = [
       'city',
@@ -126,7 +123,7 @@ function osm_civicrm_pre($op, $objectName, $id, &$params) {
     $fields_match = TRUE;
     foreach ($fields_to_check as $field) {
       if (isset($params[$field])) {
-        $fields_match = (strtolower($current_address[$field]) == strtolower($params[$field]));
+        $fields_match = (strtolower($curr_addr[$field]) == strtolower($params[$field]));
         if (!$fields_match) {
           break;
         }
@@ -136,13 +133,14 @@ function osm_civicrm_pre($op, $objectName, $id, &$params) {
     if ($fields_match) {
       // Address data is the same, now decide if we keep existing or use
       // new geo_code_x values (we don't want NULL or "Null Island")
-      $current_address_has_geo_codes = (!empty($current_address['geo_code_1']) && !empty($current_address['geo_code_2']));
-      $new_address_has_geo_codes = (!empty($params['geo_code_1']) && !empty($params['geo_code_2']));
+      $curr_addr_has_geo_codes = (!empty($curr_addr['geo_code_1']) && !empty($curr_addr['geo_code_2']));
+      $new_addr_has_geo_codes = (!empty($params['geo_code_1']) && !empty($params['geo_code_2']));
 
-      if ($current_address['manual_geo_code'] || ($current_address_has_geo_codes && !$new_address_has_geo_codes)) {
+      if ($curr_addr['manual_geo_code'] || ($curr_addr_has_geo_codes && !$new_addr_has_geo_codes)) {
         unset($params['geo_code_1']);
         unset($params['geo_code_2']);
       }
     }
+
   }
 }

--- a/osm.php
+++ b/osm.php
@@ -101,12 +101,15 @@ function osm_civicrm_managed(&$entities) {
  *
  */
 function osm_civicrm_pre($op, $objectName, $id, &$params) {
-  if ($objectName === 'Address' && $op === 'edit' && !is_null($id) && $params['manual_geo_code'] != 1) {
+  if ($objectName === 'Address' && $op === 'edit' && !is_null($id)) {
+
+    Civi::log()->debug(json_encode($params));
     $current_address = \Civi\Api4\Address::get(FALSE)
       ->addWhere('id', '=', $id)
       ->execute()
       ->first();
 
+    Civi::log()->debug(json_encode($current_address));
 
     $fields_to_check = [
       'city',
@@ -133,8 +136,8 @@ function osm_civicrm_pre($op, $objectName, $id, &$params) {
     if ($fields_match) {
       // Address data is the same, now decide if we keep existing or use
       // new geo_code_x values (we don't want NULL or "Null Island")
-      $current_address_has_geo_codes = ($current_address['geo_code_1'] && $current_address['geo_code_2']);
-      $new_address_has_geo_codes = ($params['geo_code_1'] && $params['geo_code_2']);
+      $current_address_has_geo_codes = (!empty($current_address['geo_code_1']) && !empty($current_address['geo_code_2']));
+      $new_address_has_geo_codes = (!empty($params['geo_code_1']) && !empty($params['geo_code_2']));
 
       if ($current_address['manual_geo_code'] || ($current_address_has_geo_codes && !$new_address_has_geo_codes)) {
         unset($params['geo_code_1']);

--- a/osm.php
+++ b/osm.php
@@ -159,7 +159,7 @@ function osm_civicrm_pre($op, $objectName, $id, &$params) {
       Civi::log()->debug("new_addr_has_geo_codes");
       Civi::log()->debug(json_encode($new_addr_has_geo_codes));
 
-      if ($curr_addr['manual_geo_code'] || ($curr_addr_has_geo_codes && !$new_addr_has_geo_codes)) {
+      if ($curr_addr_has_geo_codes && !$new_addr_has_geo_codes) {
         unset($params['geo_code_1']);
         unset($params['geo_code_2']);
       }

--- a/osm.php
+++ b/osm.php
@@ -115,7 +115,7 @@ function osm_civicrm_pre($op, $objectName, $id, &$params) {
     Civi::log()->debug(json_encode($params));
 
     $params = array_map(function($value) {
-      return $value == "null" ? NULL : $value;
+      return $value === "null" ? NULL : $value;
     }, $params);
 
     $curr_addr = \Civi\Api4\Address::get(FALSE)

--- a/osm.php
+++ b/osm.php
@@ -107,6 +107,10 @@ function osm_civicrm_pre($op, $objectName, $id, &$params) {
       return;
     }
 
+    $params = array_map(function($value) {
+      return $value == "null" ? NULL : $value;
+    }, $params);
+
     Civi::log()->debug("Inside pre hook. Printing params object");
     Civi::log()->debug(json_encode($params));
 
@@ -146,10 +150,9 @@ function osm_civicrm_pre($op, $objectName, $id, &$params) {
       $curr_addr_has_geo_codes = (!empty($curr_addr['geo_code_1']) && !empty($curr_addr['geo_code_2']));
       $new_addr_has_geo_codes = (!empty($params['geo_code_1']) && !empty($params['geo_code_2']));
 
-      if ($curr_addr_has_geo_codes && !$new_addr_has_geo_codes) {
-        $params['geo_code_1'] = $curr_addr['geo_code_1'];
-        $params['geo_code_2'] = $curr_addr['geo_code_2'];
-        if ($curr_addr['manual_geo_code']) unset($params['manual_geo_code']);
+      if ($curr_addr['manual_geo_code'] || ($curr_addr_has_geo_codes && !$new_addr_has_geo_codes)) {
+        unset($curr_addr['geo_code_1']);
+        unset($curr_addr['geo_code_2']);
       }
     }
 

--- a/osm.php
+++ b/osm.php
@@ -101,7 +101,7 @@ function osm_civicrm_managed(&$entities) {
  *
  */
 function osm_civicrm_pre($op, $objectName, $id, &$params) {
-  if ($objectName === 'Address' && $op === 'edit' && !is_null($id)) {
+  if ($objectName === 'Address' && $op === 'edit' && !is_null($id) && $params['manual_geo_code'] != 1) {
 
     $curr_addr = \Civi\Api4\Address::get(FALSE)
       ->addWhere('id', '=', $id)
@@ -136,9 +136,10 @@ function osm_civicrm_pre($op, $objectName, $id, &$params) {
       $curr_addr_has_geo_codes = (!empty($curr_addr['geo_code_1']) && !empty($curr_addr['geo_code_2']));
       $new_addr_has_geo_codes = (!empty($params['geo_code_1']) && !empty($params['geo_code_2']));
 
-      if ($curr_addr['manual_geo_code'] || ($curr_addr_has_geo_codes && !$new_addr_has_geo_codes)) {
-        unset($params['geo_code_1']);
-        unset($params['geo_code_2']);
+      if ($curr_addr_has_geo_codes && !$new_addr_has_geo_codes) {
+        $params['geo_code_1'] = $curr_addr['geo_code_1'];
+        $params['geo_code_2'] = $curr_addr['geo_code_2'];
+        if ($curr_addr['manual_geo_code']) unset($params['manual_geo_code']);
       }
     }
 

--- a/osm.php
+++ b/osm.php
@@ -101,6 +101,10 @@ function osm_civicrm_managed(&$entities) {
  *
  */
 function osm_civicrm_pre($op, $objectName, $id, &$params) {
+  if ($objectName === 'Address') {
+    Civi::log()->debug('Address action:');
+    Civi::log()->debug($op);
+  }
   if ($objectName === 'Address' && $op === 'edit' && !is_null($id)) {
 
     if ($params['manual_geo_code'] == 1) {

--- a/osm.php
+++ b/osm.php
@@ -116,6 +116,7 @@ function osm_civicrm_pre($op, $objectName, $id, &$params) {
       ->first();
 
     Civi::log()->debug("Printing current address");
+    Civi::log()->debug(json_encode($curr_addr));
 
     $fields_to_check = [
       'city',

--- a/osm.php
+++ b/osm.php
@@ -101,12 +101,21 @@ function osm_civicrm_managed(&$entities) {
  *
  */
 function osm_civicrm_pre($op, $objectName, $id, &$params) {
-  if ($objectName === 'Address' && $op === 'edit' && !is_null($id) && $params['manual_geo_code'] != 1) {
+  if ($objectName === 'Address' && $op === 'edit' && !is_null($id)) {
+
+    if ($params['manual_geo_code'] == 1) {
+      return;
+    }
+
+    Civi::log()->debug("Inside pre hook. Printing params object");
+    Civi::log()->debug(json_encode($params));
 
     $curr_addr = \Civi\Api4\Address::get(FALSE)
       ->addWhere('id', '=', $id)
       ->execute()
       ->first();
+
+    Civi::log()->debug("Printing current address");
 
     $fields_to_check = [
       'city',
@@ -143,5 +152,7 @@ function osm_civicrm_pre($op, $objectName, $id, &$params) {
       }
     }
 
+    Civi::log()->debug("Exiting pre hook. Printing params object");
+    Civi::log()->debug(json_encode($params));
   }
 }

--- a/osm.php
+++ b/osm.php
@@ -101,7 +101,7 @@ function osm_civicrm_managed(&$entities) {
  *
  */
 function osm_civicrm_pre($op, $objectName, $id, &$params) {
-  if ($objectName === 'Address' && $op === 'edit' && !is_null($id) && $params['manual_geo_code'] == 0) {
+  if ($objectName === 'Address' && $op === 'edit' && !is_null($id) && $params['manual_geo_code'] != 1) {
     $current_address = \Civi\Api4\Address::get(FALSE)
       ->addWhere('id', '=', $id)
       ->execute()
@@ -122,9 +122,11 @@ function osm_civicrm_pre($op, $objectName, $id, &$params) {
 
     $fields_match = TRUE;
     foreach ($fields_to_check as $field) {
-      fields_match = (strtolower($current_address[$field]) == strtolower($params[$field]);
-      if (!$fields_match) {
-        break;
+      if (isset($params[$field])) {
+        $fields_match = (strtolower($current_address[$field]) == strtolower($params[$field]));
+        if (!$fields_match) {
+          break;
+        }
       }
     }
 
@@ -134,7 +136,7 @@ function osm_civicrm_pre($op, $objectName, $id, &$params) {
       $current_address_has_geo_codes = ($current_address['geo_code_1'] && $current_address['geo_code_2']);
       $new_address_has_geo_codes = ($params['geo_code_1'] && $params['geo_code_2']);
 
-      if ($current_address_has_geo_codes && !$new_address_has_geo_codes) {
+      if ($current_address['manual_geo_code'] || ($current_address_has_geo_codes && !$new_address_has_geo_codes)) {
         unset($params['geo_code_1']);
         unset($params['geo_code_2']);
       }

--- a/osm.php
+++ b/osm.php
@@ -107,6 +107,9 @@ function osm_civicrm_pre($op, $objectName, $id, &$params) {
       return;
     }
 
+    Civi::log()->debug("Beginning pre function. Printing params");
+    Civi::log()->debug(json_encode($params));
+
     $params = array_map(function($value) {
       return $value == "null" ? NULL : $value;
     }, $params);
@@ -115,6 +118,9 @@ function osm_civicrm_pre($op, $objectName, $id, &$params) {
       ->addWhere('id', '=', $id)
       ->execute()
       ->first();
+
+    Civi::log()->debug("Printing current address");
+    Civi::log()->debug(json_encode($curr_addr));
 
     $fields_to_check = [
       'city',
@@ -144,11 +150,19 @@ function osm_civicrm_pre($op, $objectName, $id, &$params) {
       $curr_addr_has_geo_codes = (!empty($curr_addr['geo_code_1']) && !empty($curr_addr['geo_code_2']));
       $new_addr_has_geo_codes = (!empty($params['geo_code_1']) && !empty($params['geo_code_2']));
 
+      Civi::log()->debug("curr_addr_has_geo_codes");
+      Civi::log()->debug(json_encode($curr_addr_has_geo_codes));
+      Civi::log()->debug("new_addr_has_geo_codes");
+      Civi::log()->debug(json_encode($new_addr_has_geo_codes));
+
       if ($curr_addr['manual_geo_code'] || ($curr_addr_has_geo_codes && !$new_addr_has_geo_codes)) {
         unset($params['geo_code_1']);
         unset($params['geo_code_2']);
       }
     }
+
+    Civi::log()->debug("Printing params");
+    Civi::log()->debug(json_encode($params));
 
   }
 }

--- a/osm.php
+++ b/osm.php
@@ -106,8 +106,6 @@ function osm_civicrm_pre($op, $objectName, $id, &$params) {
       ->execute()
       ->first();
 
-    Civi::log()->debug(json_encode($current_address));
-    Civi::log()->debug(json_encode($params));
     $fields_to_check = [
       'city',
       'country_id',
@@ -122,17 +120,15 @@ function osm_civicrm_pre($op, $objectName, $id, &$params) {
 
     $skip_geocode = TRUE;
     foreach ($fields_to_check as $field) {
-      $skip_geocode = ($current_address[$field] == $params[$field]);
+      $skip_geocode = (strtolower($current_address[$field]) == strtolower($params[$field]);
       if (!$skip_geocode) {
         break;
       }
     }
 
-    if ($skip_geocode) {
+    if ($skip_geocode && !is_null($current_address['geo_code_1']) && $current_address['manual_geo_code'] == 0) {
       unset($params['geo_code_1']);
       unset($params['geo_code_2']);
     }
-    Civi::log()->debug('finished pre hook');
-    Civi::log()->debug(json_encode($params));
   }
 }

--- a/osm.php
+++ b/osm.php
@@ -111,16 +111,10 @@ function osm_civicrm_pre($op, $objectName, $id, &$params) {
       return $value == "null" ? NULL : $value;
     }, $params);
 
-    Civi::log()->debug("Inside pre hook. Printing params object");
-    Civi::log()->debug(json_encode($params));
-
     $curr_addr = \Civi\Api4\Address::get(FALSE)
       ->addWhere('id', '=', $id)
       ->execute()
       ->first();
-
-    Civi::log()->debug("Printing current address");
-    Civi::log()->debug(json_encode($curr_addr));
 
     $fields_to_check = [
       'city',
@@ -151,12 +145,10 @@ function osm_civicrm_pre($op, $objectName, $id, &$params) {
       $new_addr_has_geo_codes = (!empty($params['geo_code_1']) && !empty($params['geo_code_2']));
 
       if ($curr_addr['manual_geo_code'] || ($curr_addr_has_geo_codes && !$new_addr_has_geo_codes)) {
-        unset($curr_addr['geo_code_1']);
-        unset($curr_addr['geo_code_2']);
+        unset($params['geo_code_1']);
+        unset($params['geo_code_2']);
       }
     }
 
-    Civi::log()->debug("Exiting pre hook. Printing params object");
-    Civi::log()->debug(json_encode($params));
   }
 }

--- a/osm.php
+++ b/osm.php
@@ -95,24 +95,17 @@ function osm_civicrm_managed(&$entities) {
 /**
  * Implementation of hook_civicrmPre
  *
- * Used to prevent new geo_code_1 & geo_code_2 values being written to the database
+ * Used to prevent NULL geo_code_1 & geo_code_2 values being written to the database
  * when the address data being written is otherwise no different to the existing
  * address
  *
  */
 function osm_civicrm_pre($op, $objectName, $id, &$params) {
-  if ($objectName === 'Address') {
-    Civi::log()->debug('Address action:');
-    Civi::log()->debug($op);
-  }
   if ($objectName === 'Address' && $op === 'edit' && !is_null($id)) {
 
     if ($params['manual_geo_code'] == 1) {
       return;
     }
-
-    Civi::log()->debug("Beginning pre function. Printing params");
-    Civi::log()->debug(json_encode($params));
 
     $params = array_map(function($value) {
       return $value === "null" ? NULL : $value;
@@ -122,9 +115,6 @@ function osm_civicrm_pre($op, $objectName, $id, &$params) {
       ->addWhere('id', '=', $id)
       ->execute()
       ->first();
-
-    Civi::log()->debug("Printing current address");
-    Civi::log()->debug(json_encode($curr_addr));
 
     $fields_to_check = [
       'city',
@@ -154,19 +144,11 @@ function osm_civicrm_pre($op, $objectName, $id, &$params) {
       $curr_addr_has_geo_codes = (!empty($curr_addr['geo_code_1']) && !empty($curr_addr['geo_code_2']));
       $new_addr_has_geo_codes = (!empty($params['geo_code_1']) && !empty($params['geo_code_2']));
 
-      Civi::log()->debug("curr_addr_has_geo_codes");
-      Civi::log()->debug(json_encode($curr_addr_has_geo_codes));
-      Civi::log()->debug("new_addr_has_geo_codes");
-      Civi::log()->debug(json_encode($new_addr_has_geo_codes));
-
       if ($curr_addr_has_geo_codes && !$new_addr_has_geo_codes) {
         unset($params['geo_code_1']);
         unset($params['geo_code_2']);
       }
     }
-
-    Civi::log()->debug("Printing params");
-    Civi::log()->debug(json_encode($params));
 
   }
 }


### PR DESCRIPTION
This PR brings improvements to the way we handle address updates that involve lat/long values. It is a change in response to tickets raised in helpdesk, pointing out that addresses with manual geocode override enabled are having their lat/long values wiped, and other similar scenarios. This description is lengthy but outlines how I've understood the problem and therefore written the code in this PR to address it.

**Understanding the problem**
Working through this code, and reviewing the related helpdesk tickets, I'm increasingly of the opinion people have the wrong idea about the purpose of the manual override checkbox. It is not designed to "fix" the lat/long forever, but rather skip geocoding for the single transaction being carried out.

This means that we do have to accept that addresses with manual override currently set can and should be updated under certain scenarios.

So that leads to a very natural question:

When should we preserve existing lat/lng values when an address gets updated?

**Starting assumptions**
- if the address data (street, suburb, etc.) does not match between the old and new addresses, always take the new
- if the address data matches, and the new address has manual override set to yes, always take the new

**What's left?**
Eight possible scenarios are left, all occuring when the address data matches. They boil down to two sets of four scenarios, each set defined by whether or not the old address has manual override set or not:
  - old doesn't have lat/long values, new doesn't
  - old doesn't have lat/long values, new does
  - old address has lat/long values, new doesn't
  - old address has lat/long values, new does

Boiling it down to its simplest expression, we want to keep existing lat/long values whenever the address data matches and the new lat/long values are `0` or `NULL`.

**Implementing a solution**
The code in this PR explicitly handles all the scenarios described above.

**Testing**
I've tested this exhaustively across a few major activites: making a contribution, registering for an event, updating an address via the Civi UI, the API4 Explorer and submitting data via the packet system.

When manual override is set on the current/old address:
- Action: make a contribution, passing in the same data (full address)
  - Result: lat/long updated, manual override -> 0
- Action: register for an event, same data (postcode only)
  - Result: lat/long retained, manual override -> 0
- Action: Civi UI update, manual override ticked, lat/long set
  - Result: lat/long updated, manual override still set
- Action: Civi UI update, manual override unticked, lat/long set
  - Result: geocoded lat/long set, mo -> 0
- Action: Civi UI update, manual override ticked, NULL lat/long
  - Result: NULL lat/long
- Action: Civi UI update, manual override unticked, NULL lat/long
  - Result: geocoded lat/long set, mo -> 0
- Action: Packet system update
  - Result: no change (packet system doesn't even make an Address.edit call)
- Action: API4 update with lat/long
  - Result: change, mo still 1
- Action: API4 update with NULL lat/long
  - Result: no change

Manual override NOT set
- Action: make a contribution, same data (full)
  - Result: geocoded lat/long saved
- Action: register for an event, same data (postcode only)
  - Result: no change
- Action: Civi UI update, ticked, lat/long set
  - Result: lat/long updated, manual override set
- Action: Civi UI update, unticked, lat/long set
  - Result: geocoded lat/long saved
- Action: Civi UI update, ticked, NULL lat/long
  - Result: NULL lat/long, manual override set to 1
- Action: Civi UI update, unticked, NULL lat/long
  - Result: geocoded lat/long set

